### PR TITLE
Support Presidio DI components as roots

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
@@ -60,6 +60,15 @@ class DependencyProviderDeclarerTask: AbstractTask<[DependencyProvider]> {
                         return path + [component]
                     }
                 allPaths.append(contentsOf: parentAncestorPaths)
+                // If the parent is a fake root `Presidio.Component`, this parent
+                // can be instantiated anywhere. Therefore, we need to create a
+                // path with this parent as the root.
+                if parent.isPresidioComponentAsFakeRoot {
+                    let additionalPath = [parent, component]
+                    if !allPaths.contains(additionalPath) {
+                        allPaths.append(additionalPath)
+                    }
+                }
             }
             return allPaths
         }

--- a/Generator/Sources/NeedleFramework/Models/Component.swift
+++ b/Generator/Sources/NeedleFramework/Models/Component.swift
@@ -27,6 +27,8 @@ struct Component: Equatable {
     let parents : [Component]
     /// The dependency protocol data model.
     let dependency: Dependency
+    /// If this component is a fake Needle root using `Presidio.Component`.
+    let isPresidioComponentAsFakeRoot: Bool
 }
 
 /// A intermediate data model representing a component parsed straight out of
@@ -43,6 +45,8 @@ class ASTComponent {
     let properties: [Property]
     /// A list of expression call type names.
     let expressionCallTypeNames: [String]
+    /// If this component is a fake Needle root using `Presidio.Component`.
+    let isPresidioComponentAsFakeRoot: Bool
     /// The mutable list of parents.
     var parents = [ASTComponent]()
     /// The referenced dependency protocol data model.
@@ -53,14 +57,15 @@ class ASTComponent {
         let parentValues = parents.map { (parent: ASTComponent) -> Component in
             parent.valueType
         }
-        return Component(name: name, properties: properties, parents: parentValues, dependency: dependencyProtocol!)
+        return Component(name: name, properties: properties, parents: parentValues, dependency: dependencyProtocol!, isPresidioComponentAsFakeRoot: isPresidioComponentAsFakeRoot)
     }
 
     /// Initializer.
-    init(name: String, dependencyProtocolName: String, properties: [Property], expressionCallTypeNames: [String]) {
+    init(name: String, dependencyProtocolName: String, properties: [Property], expressionCallTypeNames: [String], isPresidioComponentAsFakeRoot: Bool) {
         self.name = name
         self.dependencyProtocolName = dependencyProtocolName
         self.properties = properties
         self.expressionCallTypeNames = expressionCallTypeNames
+        self.isPresidioComponentAsFakeRoot = isPresidioComponentAsFakeRoot
     }
 }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -53,11 +53,11 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
         for substructure in substructures {
             if substructure.isPluginizedComponent {
                 let (dependencyProtocolName, pluginExtensionName, nonCoreComponentName) = substructure.pluginizedGenerics
-                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames, isPresidioComponentAsFakeRoot: substructure.isPresidioComponent)
                 pluginizedComponents.append(PluginizedASTComponent(data: component, pluginExtensionType: pluginExtensionName, nonCoreComponentType: nonCoreComponentName))
             } else if substructure.isNonCoreComponent {
                 let dependencyProtocolName = substructure.dependencyProtocolName(for: "NonCoreComponent")
-                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames, isPresidioComponentAsFakeRoot: substructure.isPresidioComponent)
                 nonCoreComponents.append(component)
             } else if substructure.isPluginExtension {
                 pluginExtensions.append(PluginExtension(name: substructure.name, properties: substructure.properties))
@@ -71,6 +71,13 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
 // MARK: - SourceKit AST Parsing Utilities
 
 extension Structure {
+
+    var isPresidioComponent: Bool {
+        let regex = Regex("^Presidio.Component *<(.+)>")
+        return inheritedTypes.contains { (type: String) -> Bool in
+            regex.firstMatch(in: type) != nil
+        }
+    }
 
     var isPluginizedComponent: Bool {
         let regex = Regex("^(\(needleModuleName).)?PluginizedComponent *<(.+)>")

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
@@ -48,7 +48,7 @@ class ASTParserTask: AbstractTask<DependencyGraphNode> {
         for substructure in substructures {
             if substructure.isComponent {
                 let dependencyProtocolName = substructure.dependencyProtocolName(for: "Component")
-                components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames))
+                components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames, isPresidioComponentAsFakeRoot: substructure.isPresidioComponent))
             } else if substructure.isDependencyProtocol {
                 dependencies.append(Dependency(name: substructure.name, properties: substructure.properties))
             }


### PR DESCRIPTION
If a Needle `Component` has a parent that is a `Presidio.Component`, an additional dependency provider needs to be generated, where the `Presidio.Component` acts as the root of the branch. This is because the `Presidio.Component` can be instantiated by any object even if that object is not on the DI graph. In that case, the `Presidio.Component` is the root of an entirely new DI tree.